### PR TITLE
Make database name valid in identifier context without quotes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ package_download "postgresql" "${POSTGRESQL_VERSION}" "${BUILD_DIR}/${VENDORED_P
 
 echo "-----> Initializing database"
 export PGHOST=/tmp
-DATABASE=postgres-buildpack-db
+DATABASE=postgres_buildpack_db
 
 # Set up and configure a database for Heroku CI
 user="u$(</dev/urandom tr -dc 'a-z0-9' | head -c 13)"


### PR DESCRIPTION
If someone is programatically interacting with the database (e.g., via
ALTER DATABASE or similar), the dashes in the current identifier make
it so that the identifier must be quoted (i.e., ALTER DATABASE "$name"
rather than just allowing ALTER DATABASE $name). This is valid, but
the identifier is mostly to make it clear that it is a buildpack db,
so a fancy name is not necessary. Simplify this to allow using the
name without quotes.