### PR TITLE
Bump the version of gof3r to 0.5.0

### DIFF
--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER gregburek
 RUN apt-get -q update
 RUN apt-get -q -y install curl gcc g++ make wget unzip
 
-RUN wget -q https://github.com/rlmcpherson/s3gof3r/releases/download/v0.4.10/gof3r_0.4.10_linux_amd64.tar.gz
-RUN tar zxf gof3r_0.4.10_linux_amd64.tar.gz
-RUN mv gof3r_0.4.10_linux_amd64/gof3r .
-RUN rm -rf gof3r_0.4.10_linux_amd64*
+RUN wget -q https://github.com/rlmcpherson/s3gof3r/releases/download/v0.5.0/gof3r_0.5.0_linux_amd64.tar.gz
+RUN tar zxf gof3r_0.5.0_linux_amd64.tar.gz
+RUN mv gof3r_0.5.0_linux_amd64/gof3r .
+RUN rm -rf gof3r_0.5.0_linux_amd64*
 
 ADD postgresql-build postgresql-build
 


### PR DESCRIPTION
This bumps the version of gof3r to 0.5.0

We could possibly change this `RUN tar zxf gof3r_0.5.0_linux_amd64.tar.gz`

To this `RUN tar --strip-components=1 -zxf gof3r_0.5.0_linux_amd64.tar.gz`

Which would obviate the need to run these two lines

```
RUN mv gof3r_0.5.0_linux_amd64/gof3r .
RUN rm -rf gof3r_0.5.0_linux_amd64*
```
