### PR TITLE
Bump postgres to 10.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ set -e
 unset GIT_DIR
 
 # config
-POSTGRESQL_VERSION="9.6.6"
+POSTGRESQL_VERSION="10.1"
 S3_BUCKET="ci-database-binary"
 
 # parse and derive params


### PR DESCRIPTION
**Cedar-14**

```
› curl -I https://ci-database-binary.s3.amazonaws.com/cedar-14/postgresql-10.1.tgz
HTTP/1.1 200 OK
x-amz-id-2: XgjDme903ajrcsPYIyzeZ0X8Ceoh8boGHwl2CXSAKydIvHdXicX1qAgKRxz1k2Pmc6fs/84JlVo=
x-amz-request-id: 70CBBA06B7B2D7F4
Date: Mon, 11 Dec 2017 14:47:14 GMT
Last-Modified: Mon, 11 Dec 2017 14:46:07 GMT
ETag: "8a8f619ca909c1ae8069b48dd8e7b30d-2"
Accept-Ranges: bytes
Content-Type: binary/octet-stream
Content-Length: 23946277
Server: AmazonS3
```

**Heroku-16**

```
› curl -I https://ci-database-binary.s3.amazonaws.com/heroku-16/postgresql-10.1.tgz
HTTP/1.1 200 OK
x-amz-id-2: mbnxI/66aiSk0WZPdDug90ITywzzBqn9fmTpyvX773XO/svw7BkCcTfz3QC/usx/02sg3REfeGI=
x-amz-request-id: C28C5ECBFC0E89C8
Date: Mon, 11 Dec 2017 14:40:03 GMT
Last-Modified: Mon, 11 Dec 2017 14:33:58 GMT
ETag: "e38aa98acc32b48373ec46f020ca03e6-2"
Accept-Ranges: bytes
Content-Type: binary/octet-stream
Content-Length: 24441809
Server: AmazonS3
```