### PR TITLE
Support multiple versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Please note that Postgresql will lose all data each time a dyno restarts.
 This is intended to be transparent to your application. Connect to the database
 in the same way as you would for [Heroku Postgresql](https://www.heroku.com/postgres)
 by reading the value of the `DATABASE_URL` environment variable into your application.
+
+By default, the buildpack provides the latest Postgres version that is
+generally available on Heroku. You can specify a `POSTGRESQL_VERSION`
+in the `env` section of your
+[app.json](https://devcenter.heroku.com/articles/heroku-ci#environment-variables-env-key)
+to use a different major (e.g., "10" or "9.6") version. This feature
+is experimental and subject to change.

--- a/bin/compile
+++ b/bin/compile
@@ -10,15 +10,26 @@ set -e
 # clean up leaking environment
 unset GIT_DIR
 
-# config
-POSTGRESQL_VERSION="10.1"
-S3_BUCKET="ci-database-binary"
-
 # parse and derive params
 BUILD_DIR=$1
 CACHE_DIR=$2
+ENV_DIR=$3
 LP_DIR=`cd $(dirname $0); cd ..; pwd`
 BUILDPACK_DIR="$(dirname $(dirname $0))"
+
+# config
+S3_BUCKET="ci-database-binary"
+POSTGRESQL_MAJOR_VERSION=10
+if [ -f "$ENV_DIR/POSTGRESQL_VERSION" ]
+then
+  POSTGRESQL_MAJOR_VERSION="$(cat $ENV_DIR/POSTGRESQL_VERSION)"
+fi
+
+case "$POSTGRESQL_MAJOR_VERSION" in
+  10)  POSTGRESQL_VERSION="10.1";;
+  9.6) POSTGRESQL_VERSION="9.6.6";;
+  *)   POSTGRESQL_VERSION="$POSTGRESQL_MAJOR_VERSION";;
+esac
 
 function error() {
   echo " !     $*" >&2
@@ -41,6 +52,10 @@ function package_download() {
 
   mkdir -p $location
   package="https://${S3_BUCKET}.s3.amazonaws.com/$stack/$engine-$version.tgz"
+  if ! wget --spider $package 2>/dev/null
+  then
+    error "Specified postgresql version ${POSTGRESQL_VERSION} is not available"
+  fi
   curl $package -s -o - | tar xzf - -C $location
 }
 


### PR DESCRIPTION
I've tested this on the `test-pgversion-for-postgres-ci-buildpack` branch of DHC [here](https://dashboard.heroku.com/pipelines/e3c307cc-1d33-4c82-8884-73a533d8314f/tests/969). I've confirmed it selects a correct alternate version when specified, that it still defaults to the correct version, and that the error handling for requesting a non-existent version works correctly.

Fixes #1