### PR TITLE
Specify UTF-8 as default encoding for initdb

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -88,6 +88,12 @@ user="u$(</dev/urandom tr -dc 'a-z0-9' | head -c 13)"
 password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
 
 export PGDATA=$BUILD_DIR/vendor/postgresql/data
+LC_COLLATE=en_US.UTF-8  \
+LC_CTYPE=en_US.UTF-8    \
+LC_MESSAGES=en_US.UTF-8 \
+LC_MONETARY=en_US.UTF-8 \
+LC_NUMERIC=en_US.UTF-8  \
+LC_TIME=en_US.UTF-8     \
 initdb -E UTF8 | indent
 pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent

--- a/bin/compile
+++ b/bin/compile
@@ -88,7 +88,7 @@ user="u$(</dev/urandom tr -dc 'a-z0-9' | head -c 13)"
 password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
 
 export PGDATA=$BUILD_DIR/vendor/postgresql/data
-initdb | indent
+initdb -E UTF8 | indent
 pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent


### PR DESCRIPTION
Currently, the locale is unset as part of this buildpack, so the
default encoding is `SQL_ASCII`, which is different to the add-on
default encoding of `UTF8`.

This commit specifies `UTF8` as the encoding for the template database
by passing it to `initdb`'s `-E` switch, and brings parity with the add-on version
of Heroku Postgres.

Fixes https://github.com/heroku/heroku-buildpack-ci-postgresql/issues/2