### PR TITLE
Allow heroku-18 stack and bump default postgres version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,8 +26,8 @@ then
 fi
 
 case "$POSTGRESQL_MAJOR_VERSION" in
-  10)  POSTGRESQL_VERSION="10.1";;
-  9.6) POSTGRESQL_VERSION="9.6.6";;
+  10)  POSTGRESQL_VERSION="10.5";;
+  9.6) POSTGRESQL_VERSION="9.6.9";;
   *)   POSTGRESQL_VERSION="$POSTGRESQL_MAJOR_VERSION";;
 esac
 
@@ -65,6 +65,8 @@ case $STACK in
     cedar-14) : ;;
     heroku-16) : ;;
     heroku-16-build) : ;;
+    heroku-18) ;;
+    heroku-18-build) ;;
     *) error "Unrecognized stack version: ${STACK}";;
 esac
 

--- a/support/README.md
+++ b/support/README.md
@@ -17,18 +17,18 @@ docker run -e "S3_BUCKET=ci-database-binary" \
 This should create a docker image called `postgresql-builder` and then build
 postgresql inside the image, and upload it to the S3 bucket.
 
-# Building for heroku-16
+# Building for heroku-*
 
 Modify the `Dockerfile`
 
 ```
 -FROM heroku/cedar:14
-+FROM heroku/heroku:16
++FROM heroku/heroku:<version>
 ```
 
 Modify the `postgresql-build` file.
 
 ```
 -tar -zcf - . | /gof3r put -b $S3_BUCKET -k cedar-14/postgresql-$POSTGRESQL_VERSION.tgz
-+tar -zcf - . | /gof3r put -b $S3_BUCKET -k heroku-16/postgresql-$POSTGRESQL_VERSION.tgz --acl public-read
++tar -zcf - . | /gof3r put -b $S3_BUCKET -k heroku-<version>/postgresql-$POSTGRESQL_VERSION.tgz --acl public-read
 ```

--- a/support/postgresql-build
+++ b/support/postgresql-build
@@ -15,6 +15,7 @@ CFLAGS='-fPIC -DLINUX_OOM_ADJ=0'
 
 apt-get install uuid-dev
 
+# keep this in sync with https://devcenter.heroku.com/articles/heroku-ci-in-dyno-databases#restrictions
 ./configure --prefix=/app/vendor/postgresql \
             --enable-integer-datetimes \
             --enable-thread-safety \


### PR DESCRIPTION
- [x] Allow `heroku-18` and `heroku-18-build` stacks
- [x] Upload postgres packages for `10.5` for all stacks that need it
- [x] Upload postgres packages for `9.6.9` for all stacks that need it