### PR TITLE
Create background file for CI to execute

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -126,4 +126,13 @@ cat<<EOF > $BUILD_DIR/.profile.d/pg-env.sh
 export DATABASE_URL="$DATABASE_URL"
 EOF
 
+cat<<EOF > $BUILDPACK_DIR/background
+PATH=$HOME/vendor/postgresql/bin:$PATH
+export PGHOST="$PGHOST"
+export DATABASE_URL="$DATABASE_URL"
+export PGHOST=/tmp
+export PGDATA=$HOME/vendor/postgresql/data
+pg_ctl -w restart >/dev/null
+EOF
+
 echo "-----> postgresql done"


### PR DESCRIPTION
Heroku CI will execute the `$BUILDPACK_DIR/background` file after the `compile` step is complete. This will be needed as any processes launched during `compile` will be terminated.