### PR TITLE
Order .profile.d scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+sudo: false
+script: exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -108,9 +108,9 @@ echo "export PGHOST=$PGHOST" >> $BUILDPACK_DIR/export
 echo "export DATABASE_URL=$DATABASE_URL" >> $BUILDPACK_DIR/export
 
 # setting .profile.d script for database startup
-echo "-----> Copying .profile.d/pg.sh to add postgresql binaries to PATH"
+echo "-----> Copying .profile.d/00-pg-path.sh to add postgresql binaries to PATH"
 mkdir -p $BUILD_DIR/.profile.d
-cat<<\EOF > $BUILD_DIR/.profile.d/pg-path.sh
+cat<<\EOF > $BUILD_DIR/.profile.d/00-pg-path.sh
 PATH=$HOME/.indyno/vendor/postgresql/bin:$PATH
 
 export PGHOST=/tmp
@@ -122,7 +122,7 @@ then
 fi
 EOF
 
-cat<<EOF > $BUILD_DIR/.profile.d/pg-env.sh
+cat<<EOF > $BUILD_DIR/.profile.d/01-pg-env.sh
 export DATABASE_URL="$DATABASE_URL"
 EOF
 


### PR DESCRIPTION
In order to prevent other scripts in `.profile.d` from trying to access an exported `env` var like `DATABASE_URL` and it being blank. This could happen if the script was named anything that would sort before `pg-env.sh`

I pinged you @tt because you suggested it. Not sure if we should do anything more. It seems straight forward.