### PR TITLE
Don't attempt to restart when postgres isn't running

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -132,7 +132,11 @@ export PGHOST="$PGHOST"
 export DATABASE_URL="$DATABASE_URL"
 export PGHOST=/tmp
 export PGDATA=$HOME/.indyno/vendor/postgresql/data
-pg_ctl -w restart >/dev/null
+if pg_ctl status; then
+  pg_ctl -w restart
+else
+  pg_ctl -w start
+fi
 EOF
 
 echo "-----> Postgresql done"

--- a/bin/compile
+++ b/bin/compile
@@ -132,10 +132,10 @@ export PGHOST="$PGHOST"
 export DATABASE_URL="$DATABASE_URL"
 export PGHOST=/tmp
 export PGDATA=$HOME/.indyno/vendor/postgresql/data
-if pg_ctl status; then
-  pg_ctl -w restart
+if pg_ctl status >/dev/null; then
+  pg_ctl -l .pg.log -w restart >/dev/null
 else
-  pg_ctl -w start
+  pg_ctl -l .pg.log -w start >/dev/null
 fi
 EOF
 


### PR DESCRIPTION
In some rare cases, postgres is not running when we attempt to restart it. Restarting when postgres isn't running will fail an entire test run. This change restarts if postgres is running, and starts postgres if it is not.