### PR TITLE
turn off fsync

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -98,7 +98,7 @@ LC_MONETARY=en_US.UTF-8 \
 LC_NUMERIC=en_US.UTF-8  \
 LC_TIME=en_US.UTF-8     \
 initdb -E UTF8 | indent
-if [ -f "$ENV_DIR/PG_TUNING" ]
+if [ -f "$ENV_DIR/HEROKU_CI_POSTGRES_FSYNC_OFF" ]
 then
   echo "-----> Setting fsync=off in /app/.indyno/vendor/postgresql/data/postgresql.conf"
   echo "fsync=off" >> /app/.indyno/vendor/postgresql/data/postgresql.conf

--- a/bin/compile
+++ b/bin/compile
@@ -98,6 +98,11 @@ LC_MONETARY=en_US.UTF-8 \
 LC_NUMERIC=en_US.UTF-8  \
 LC_TIME=en_US.UTF-8     \
 initdb -E UTF8 | indent
+if [ -f "$ENV_DIR/PG_TUNING" ]
+then
+  echo "-----> Setting fsync=off in /app/.indyno/vendor/postgresql/data/postgresql.conf"
+  echo "fsync=off" >> /app/.indyno/vendor/postgresql/data/postgresql.conf
+fi
 pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent


### PR DESCRIPTION
hey 👋 

this Postgres database is only running in CI and we can improvement over durability here.
This allows to turn fsync off if you set the `HEROKU_CI_POSTGRES_FSYNC_OFF` env var.
Test time improvements depend on your tests, we saw improvements between 3% and 70%

thanks