### PR TITLE
Test the buildpack in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+support/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,26 @@
-sudo: false
-script: exit 0
+language: bash
+services:
+  - docker
+env:
+  - STACK=cedar-14 POSTGRESQL_VERSION=9.6
+  - STACK=cedar-14 POSTGRESQL_VERSION=10
+  - STACK=cedar-14 POSTGRESQL_VERSION=11
+  - STACK=cedar-14 POSTGRESQL_VERSION=12
+
+  - STACK=heroku-16 POSTGRESQL_VERSION=9.6
+  - STACK=heroku-16 POSTGRESQL_VERSION=10
+  - STACK=heroku-16 POSTGRESQL_VERSION=11
+  - STACK=heroku-16 POSTGRESQL_VERSION=12
+
+  - STACK=heroku-18 POSTGRESQL_VERSION=9.6
+  - STACK=heroku-18 POSTGRESQL_VERSION=10
+  - STACK=heroku-18 POSTGRESQL_VERSION=11
+  - STACK=heroku-18 POSTGRESQL_VERSION=12
+
+  # Test relying on the buildpack's default PostgreSQL version.
+  - STACK=heroku-18
+
+  # Test specifying an exact point release version.
+  - STACK=heroku-18 POSTGRESQL_VERSION=11.7
+script:
+  - ./support/test.sh "${STACK}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ARG STACK
+ARG POSTGRESQL_VERSION
+
+# initdb and pg_ctl error if run as root.
+RUN useradd -m -d /app non-root-user
+RUN mkdir -p /app /cache /env
+RUN chown non-root-user /app /cache /env
+USER non-root-user
+
+RUN [ -z "${POSTGRESQL_VERSION}" ] || echo "${POSTGRESQL_VERSION}" > /env/POSTGRESQL_VERSION
+COPY --chown=non-root-user . /buildpack
+WORKDIR /app
+
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env

--- a/support/test.sh
+++ b/support/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
+
+STACK="${1}"
+
+if [[ "${STACK}" == "cedar-14" ]]; then
+    BASE_IMAGE="heroku/${STACK/-/:}"
+else
+    BASE_IMAGE="heroku/${STACK/-/:}-build"
+fi
+
+OUTPUT_IMAGE="postgresql-test-${STACK}"
+
+echo "Building buildpack on stack ${STACK}..."
+
+docker build \
+    --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+    --build-arg "STACK=${STACK}" \
+    ${POSTGRESQL_VERSION:+--build-arg "POSTGRESQL_VERSION=${POSTGRESQL_VERSION}"} \
+    -t "${OUTPUT_IMAGE}" \
+    .
+
+echo "Checking PostgreSQL server presence and version..."
+
+TEST_COMMAND="for f in .profile.d/*; do source \"\$f\"; done && psql -tAc 'SHOW server_version;' \"\$DATABASE_URL\" | grep \"${POSTGRESQL_VERSION:-}\""
+docker run --rm -it "${OUTPUT_IMAGE}" bash -c "${TEST_COMMAND}"
+
+echo "Success!"


### PR DESCRIPTION
Since previously the Travis run was a no-op, and we're about to add support for a new stack, which would be good to test properly.

Uses an approach similar to that in:
https://github.com/heroku/heroku-buildpack-ci-redis

Fixes [W-6167776](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000006toXeIAI/view).