### PR TITLE
Remove support for Cedar-14 and Heroku-16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ workflows:
                   matrix:
                       parameters:
                           pg_version: ["9.6", "10", "11", "12", "13"]
-                          stack: [heroku-16, heroku-18, heroku-20]
+                          stack: [heroku-18, heroku-20]
             - test:
                   pg_version: ""
                   stack: heroku-18

--- a/bin/compile
+++ b/bin/compile
@@ -64,7 +64,6 @@ function package_download() {
 echo "Using postgresql version: ${POSTGRESQL_VERSION}" | indent
 
 case $STACK in
-    heroku-16) : ;;
     heroku-18) ;;
     heroku-20) ;;
     *) error "Unrecognized stack version: ${STACK}";;

--- a/support/build-postgresql
+++ b/support/build-postgresql
@@ -24,7 +24,7 @@ IFS=';' read -ra PGSQL_VERSIONS <<< "$(cat $PG_VERSIONS_FILE)"
 
 for PGSQL_VERSION in "${PGSQL_VERSIONS[@]}"; do
   PGSQL_VERSION=$(echo "$PGSQL_VERSION" | tr -d '[:space:]') # '12.2 ' -> '12.2'
-  for stack in cedar-14 heroku-{16,18,20}; do
+  for stack in heroku-{18,20}; do
     echo "Building PG $PGSQL_VERSION for $stack..."
     BASE_IMAGE="heroku/${stack/-/:}" # heroku-18 -> heroku/heroku:18
     docker build \


### PR DESCRIPTION
Since it's no longer possible to build with those stacks on the Heroku platform, as the build system for them no longer exists.

See:
https://help.heroku.com/SMQ1J712/cedar-14-end-of-life-faq
https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

Fixes #46.