### PR TITLE
feat: pre-create heroku_ext schema to mirror production

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ is experimental and subject to change.
 
 If you want to turn off fsync during your test, you can set `HEROKU_CI_POSTGRES_FSYNC_OFF` in your [app.json env](https://devcenter.heroku.com/articles/heroku-ci#setting-environment-variables-the-env-key) section.
 
+## heroku_ext extension schema
+
+By default, this buildpack will create the `heroku_ext` schema to better reflect production databases.
+
+To disable this, you can set `HEROKU_CI_POSTGRES_HEROKU_EXT_OFF` in your [app.json env](https://devcenter.heroku.com/articles/heroku-ci#setting-environment-variables-the-env-key) section.
+
 ## Releasing a new version
 
 Follow the [playbook](https://github.com/heroku/engineering-docs/blob/master/components/heroku-buildpack-ci-postgresql/update-version.md).

--- a/bin/compile
+++ b/bin/compile
@@ -107,6 +107,15 @@ pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent
 DATABASE_URL="postgres://${user}:${password}@localhost:5432/${DATABASE}"
+
+if [ -f "$ENV_DIR/HEROKU_CI_POSTGRES_HEROKU_EXT_OFF" ]
+then
+  echo "-----> Skipping heroku_ext support"
+else
+  echo "-----> Creating heroku_ext schema for extensions"
+  psql "$DATABASE_URL" -c "CREATE SCHEMA heroku_ext" | indent
+fi
+
 # N.B.: we do not stop the server here because some buildpacks rely on
 # having a live database at DATABASE_URL in order to run the build
 


### PR DESCRIPTION
Pre-creates a `heroku_ext` schema for better prod/ci parity.

Testing

1. create an app
2. set the app to use this buildpack with this branch
3. deploy
4. connect to psql on a dyno and verify that the heroku_ext schema is present
5. set the `HEROKU_CI_POSTGRES_HEROKU_EXT_OFF` config var on the app
6. deploy
7. connect to psql on a dyno and verify that the heroku_ext schema is NOT present 
