### PR TITLE
Add missing shebang

### DIFF
--- a/support/postgresql-build
+++ b/support/postgresql-build
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -euo pipefail
 set -o xtrace
 


### PR DESCRIPTION
Recent GitHub action execution fails with `./postgresql-build: 1: set: Illegal option -o pipefail`