### PR TITLE
Switch to AWS' dual-stack S3 URLs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,7 +53,7 @@ function package_download() {
   stack="$4"
 
   mkdir -p $location
-  package="https://${S3_BUCKET}.s3.amazonaws.com/$stack/$engine-$version.tgz"
+  package="https://${S3_BUCKET}.s3.dualstack.us-east-1.amazonaws.com/$stack/$engine-$version.tgz"
   if ! wget --spider $package 2>/dev/null
   then
     error "Specified postgresql version ${POSTGRESQL_VERSION} is not available"


### PR DESCRIPTION
The default AWS S3 URLs only support IPv4, whereas the dual-stack URLs support both IPv4 and IPv6:
https://docs.aws.amazon.com/AmazonS3/latest/API/ipv6-access.html
https://docs.aws.amazon.com/AmazonS3/latest/API/dual-stack-endpoints.html

By switching to the dual-stack URLs, it means systems that support IPv6 will now use it instead of IPv4, which is helpful in IPv6 environments where IPv4 traffic has to fall back to being routed via NAT gateways (which has performance and ingress cost implications).

See also:
https://salesforce-internal.slack.com/archives/C01R6FJ738U/p1770827176094169

GUS-W-21348389.